### PR TITLE
Lps 88220

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/LicenseUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/LicenseUtil.java
@@ -677,13 +677,6 @@ public class LicenseUtil {
 				if (sigar != null) {
 					sigar.close();
 				}
-
-				try {
-					SigarNativeLoader.unload();
-				}
-				catch (Exception e) {
-					throw new ProcessException(e);
-				}
 			}
 		}
 


### PR DESCRIPTION
@amosfong that reflect trick for unloading breaks in Java 11.
Now since we already pushed sigar into a new separate jvm, there is no point to unload anything any more, the new jvm is dedicated for sigar. We can just let it die normally.

CC @vicnate5