### PR TITLE
LPD-93311 Add unit tests for the SEO parameter name fallback

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortletPreferencesImplTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortletPreferencesImplTest.java
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.custom.facet.portlet;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletPreferences;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Prathima Shreenath
+ */
+public class CustomFacetPortletPreferencesImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetSEOParameterNameWhenParameterNameIsNull() {
+		PortletPreferences portletPreferences = Mockito.mock(
+			PortletPreferences.class);
+
+		_mockValue(
+			portletPreferences,
+			CustomFacetPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
+			StringPool.BLANK);
+		_mockValue(
+			portletPreferences,
+			CustomFacetPortletPreferences.PREFERENCE_KEY_AGGREGATION_FIELD,
+			"userName");
+
+		Assert.assertEquals(
+			"userName",
+			new CustomFacetPortletPreferencesImpl(
+				portletPreferences
+			).getSEOParameterName());
+	}
+
+	@Test
+	public void testGetSEOParameterNameWhenParameterNameIsSet() {
+		PortletPreferences portletPreferences = Mockito.mock(
+			PortletPreferences.class);
+
+		_mockValue(
+			portletPreferences,
+			CustomFacetPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
+			"customParameter");
+		_mockValue(
+			portletPreferences,
+			CustomFacetPortletPreferences.PREFERENCE_KEY_AGGREGATION_FIELD,
+			"userName");
+
+		Assert.assertEquals(
+			"customParameter",
+			new CustomFacetPortletPreferencesImpl(
+				portletPreferences
+			).getSEOParameterName());
+	}
+
+	private void _mockValue(
+		PortletPreferences portletPreferences, String key, String value) {
+
+		Mockito.when(
+			portletPreferences.getValue(key, StringPool.BLANK)
+		).thenReturn(
+			value
+		);
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferencesImplTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/filter/portlet/CustomFilterPortletPreferencesImplTest.java
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.web.internal.custom.filter.portlet;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletPreferences;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Prathima Shreenath
+ */
+public class CustomFilterPortletPreferencesImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetSEOParameterNameWhenParameterNameIsNull() {
+		PortletPreferences portletPreferences = Mockito.mock(
+			PortletPreferences.class);
+
+		_mockValue(
+			portletPreferences,
+			CustomFilterPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
+			StringPool.BLANK);
+		_mockValue(
+			portletPreferences,
+			CustomFilterPortletPreferences.PREFERENCE_KEY_FILTER_FIELD,
+			"modified");
+
+		Assert.assertEquals(
+			"modified",
+			new CustomFilterPortletPreferencesImpl(
+				portletPreferences
+			).getSEOParameterName());
+	}
+
+	@Test
+	public void testGetSEOParameterNameWhenParameterNameIsSet() {
+		PortletPreferences portletPreferences = Mockito.mock(
+			PortletPreferences.class);
+
+		_mockValue(
+			portletPreferences,
+			CustomFilterPortletPreferences.PREFERENCE_KEY_PARAMETER_NAME,
+			"customParameter");
+		_mockValue(
+			portletPreferences,
+			CustomFilterPortletPreferences.PREFERENCE_KEY_FILTER_FIELD,
+			"modified");
+
+		Assert.assertEquals(
+			"customParameter",
+			new CustomFilterPortletPreferencesImpl(
+				portletPreferences
+			).getSEOParameterName());
+	}
+
+	private void _mockValue(
+		PortletPreferences portletPreferences, String key, String value) {
+
+		Mockito.when(
+			portletPreferences.getValue(key, StringPool.BLANK)
+		).thenReturn(
+			value
+		);
+	}
+
+}


### PR DESCRIPTION
Covers the getSEOParameterName fallback in both CustomFilterPortletPreferencesImpl and CustomFacetPortletPreferencesImpl, which returns the configured parameter name and otherwise falls back to the filter field or aggregation field respectively. The Custom Facet fallback predated this change and had no coverage.